### PR TITLE
Add configurable alpha weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# MT5 Trading Bot
+
+This project contains an automated trading bot for MetaTrader 5 that uses machine learning models.
+
+## Configuration
+
+When run for the first time, the bot creates a `config.json` file with the following default values:
+
+```json
+{
+  "interval": 1,
+  "max_ops": 5,
+  "min_confidence": 0.75,
+  "backtest_days": 182,
+  "auto": false,
+  "login": null,
+  "server": null,
+  "alpha": 0.7
+}
+```
+
+### `alpha`
+Controls the weight of the supervised model when combining probabilities with the unsupervised model inside the trading loop. The value must be between `0` and `1` and defaults to `0.7`.

--- a/metatrader5Bot.pyw
+++ b/metatrader5Bot.pyw
@@ -97,7 +97,8 @@ def load_config():
         "backtest_days":  182,
         "auto":           False,
         "login":          None,
-        "server":         None
+        "server":         None,
+        "alpha":          0.7
     }
 
     if not os.path.exists(CONFIG_FILE):
@@ -711,7 +712,8 @@ class TradingBot:
                 hist["initial_balance"] = acc.balance
                 save_history(hist)
 
-        alpha = 0.7  # peso para el modelo supervisado en la confianza combinada
+        cfg = load_config()
+        alpha = cfg.get("alpha", 0.7)  # peso para el modelo supervisado en la confianza combinada
         self._last_feat = None  # inicializamos el atributo
 
         while self.trading_mode:
@@ -720,6 +722,7 @@ class TradingBot:
                 cfg = load_config()
                 interval = cfg.get("interval", interval)
                 max_ops  = cfg.get("max_ops", max_ops)
+                alpha    = cfg.get("alpha", alpha)
                 start_time = time.time()
 
                 # 1) Gestionar stops y cierres forzosos


### PR DESCRIPTION
## Summary
- configure default `alpha` value in `load_config`
- read the `alpha` parameter inside `TradingBot.trading_loop`
- document all config options including `alpha` in README

## Testing
- `python3 -m py_compile metatrader5Bot.pyw`


------
https://chatgpt.com/codex/tasks/task_e_685038ab820c8324a291107191c33b7b